### PR TITLE
Go 1.11 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ _Usage_:
 Run this tool in the root folder of your source.
 
 `docker-windows-volume-watcher -container=[name of the container your volume is mounted in]`
+
+You can also specify the path to watch:
+
+`docker-windows-volume-watcher -container=[container name] -path=[path to watch]`

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/FrodeHus/docker-windows-volume-watcher
+
+require (
+	github.com/fsnotify/fsnotify v1.4.7
+	golang.org/x/sys v0.0.0-20181218192612-074acd46bca6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
+github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+golang.org/x/sys v0.0.0-20181218192612-074acd46bca6 h1:MXtOG7w2ND9qNCUZSDBGll/SpVIq7ftozR9I8/JGBHY=
+golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Hello, this PR implements Go 1.11 modules (`go.sum` and `go.mod` files), allowing `go build` to "just work".