### PR TITLE
Fixes, optimizations and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,26 @@ Simple utility to get HMR working with WebPack inside containers running on Dock
 
 Inspired by [Mikhail Erofeev's Python tool](https://github.com/merofeev/docker-windows-volume-watcher)
 
-_Usage_:
+## Usage
+
 Run this tool in the root folder of your source.
 
 `docker-windows-volume-watcher -container=[name of the container your volume is mounted in]`
 
-You can also specify the path to watch:
+### Arguments
 
-`docker-windows-volume-watcher -container=[container name] -path=[path to watch]`
+```
+Usage of docker-windows-volume-watcher:
+
+  -container string
+        Name of the container instance that you wish to notify of filesystem changes
+
+  -delay int
+        Delay in milliseconds before notifying about a file that's changed (default 100)
+
+  -ignore string
+        Semicolon-separated list of directories to ignore. Glob expressions are supported. (default "node_modules;vendor")
+
+  -path string
+        Root path where to watch for changes
+```

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 		fmt.Println("ERROR", err)
 	}
 
+	// Map of filenames we're currently notifying about.
 	var processes sync.Map
 
 	for {
@@ -54,11 +55,11 @@ func main() {
 		case event := <-watcher.Events:
 			switch event.Op {
 			case fsnotify.Write:
-				fmt.Println(time.Now())
 				if _, ok := processes.Load(event.Name); ok {
 					continue
 				}
 				processes.Store(event.Name, nil)
+
 				go func(event fsnotify.Event) {
 					defer processes.Delete(event.Name)
 
@@ -73,6 +74,7 @@ func main() {
 
 					notifyDocker(event)
 				}(event)
+
 			case fsnotify.Rename, fsnotify.Remove:
 				processes.Delete(event.Name)
 			}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 func init() {
 	flag.StringVar(&container, "container", "", "Name of the container instance that you wish to notify of filesystem changes")
 	flag.StringVar(&rootPath, "path", "", "Root path where to watch for changes")
-	flag.StringVar(&ignoreArg, "ignore", ".git;node_modules;vendor", "Semicolon-separated list of directories to ignore. "+
+	flag.StringVar(&ignoreArg, "ignore", "node_modules;vendor", "Semicolon-separated list of directories to ignore. "+
 		"Glob expressions are supported.")
 }
 
@@ -96,19 +96,22 @@ func watchDir(path string, fi os.FileInfo, err error) error {
 	if !fi.Mode().IsDir() {
 		return nil
 	}
+
+	// Ignore hidden directories.
 	if len(path) > 1 && strings.HasPrefix(path, ".") {
-		// Ignore hidden directories.
-		return nil
+		return filepath.SkipDir
 	}
+
 	for _, pattern := range ignores {
 		ok, err := filepath.Match(pattern, fi.Name())
 		if err != nil {
 			return err
 		}
 		if ok {
-			return nil
+			return filepath.SkipDir
 		}
 	}
+
 	fmt.Println("Watching ", path)
 	return watcher.Add(path)
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
@@ -74,19 +73,7 @@ func notifyDocker(event fsnotify.Event) {
 	}
 	fmt.Println("Updating container file ", containerPath)
 
-	result, err := exec.Command("docker", "exec", container, "stat", "-c", "%a", containerPath).Output()
-	if err != nil {
-		fmt.Println("Error retrieving file permissions: ", err)
-	}
-
-	perms, err := strconv.Atoi(strings.TrimSuffix(string(result), "\n"))
-	if err != nil {
-		fmt.Println("Raw permissions: ", result)
-		fmt.Println("Failed to convert permissions: ", err)
-		return
-	}
-
-	_, err = exec.Command("docker", "exec", container, "/bin/sh", "-c", fmt.Sprintf("chmod %d %s", perms, containerPath)).Output()
+	_, err := exec.Command("docker", "exec", container, "/bin/sh", "-c", fmt.Sprintf("chmod $(stat -c %%a %s) %s", containerPath, containerPath)).Output()
 	if err != nil {
 		fmt.Printf("Error notifying container about file change: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func notifyDocker(event fsnotify.Event) {
 
 	_, err := exec.Command("docker", "exec", container, "/bin/sh", "-c", fmt.Sprintf("chmod $(stat -c %%a %s) %s", containerPath, containerPath)).Output()
 	if err != nil {
-		fmt.Printf("Error notifying container about file change: %v", err)
+		fmt.Printf("Error notifying container about file change: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
I've made the following changes:

1. Fixed to watch root directory. Previously, the `.` directory wasn't being watched.
2. Added --ignore argument which accepts a list of directories to not watch (glob expressions supported).
3. Made faster by combining two `docker exec` calls into one.
4. Added per-file delay before calling `docker exec` to help accommodate the way editors save files (they trigger more than one event per file per save).

Hope this helps ;-)